### PR TITLE
Refactor API Request

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -50,15 +50,15 @@ function App() {
   }
 
   function savePlaylist() {
-    const trackURIs = playlistTracks.map(track => track.uri);
-    if (!trackURIs.length) {
+    const currentTrackURIs = playlistTracks.map(track => track.uri);
+    if (!currentTrackURIs.length) {
       return activateMsg('Tracks required.', '#FF0000');
     }
     if (!playlistName) {
       return activateMsg('Playlist name required.', '#FF0000');
     }
     if (!editMode) {
-      Spotify.savePlaylist(playlistName, trackURIs).then(() => {
+      Spotify.savePlaylist(playlistName, currentTrackURIs).then(() => {
         activateMsg('Playlist saved!', '#228B22');
         setPlaylistName('New Playlist');
         setPlaylistTracks([]);
@@ -68,8 +68,8 @@ function App() {
     if (editMode) {
       // When saving an existing playlist, remove all previously saved tracks and then save all current playlist tracks to Spotify.
       Spotify.renamePlaylist(playlistName, playlistId)
-      .then(Spotify.deleteTracks(oldTrackURIs, playlistId))
-      .then(Spotify.addTracks(trackURIs, playlistId))
+      .then(Spotify.deleteTracks(previousTrackURIs, playlistId))
+      .then(Spotify.addTracks(currentTrackURIs, playlistId))
       .then(() => {
         activateMsg('Playlist updated!', '#228B22');
         setPlaylistName('New Playlist');

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -49,7 +49,7 @@ function App() {
     setSearchResults([...searchResults]);
   }
 
-  function savePlaylist() {
+  async function savePlaylist() {
     const currentTrackURIs = playlistTracks.map(track => track.uri);
     if (!currentTrackURIs.length) {
       return activateMsg('Tracks required.', '#FF0000');
@@ -66,6 +66,8 @@ function App() {
       });
     }
     if (editMode) {
+      const previousTracks = await Spotify.getPlaylistTracks(playlistId);
+      const previousTrackURIs = previousTracks.map(track => track.uri);
       // When saving an existing playlist, remove all previously saved tracks and then save all current playlist tracks to Spotify.
       Spotify.renamePlaylist(playlistName, playlistId)
       .then(Spotify.deleteTracks(previousTrackURIs, playlistId))

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -38,11 +38,6 @@ function App() {
       searchResults.splice(index, 1);
       setSearchResults([...searchResults]);
     }
-    if (editMode) {
-      Spotify.addTrack(track.uri, playlistId).then(() => {
-        activateMsg('Track added!', '#228B22');
-      });
-    }
   }
 
   function removeTrack(track) {
@@ -52,11 +47,6 @@ function App() {
     // Add track back to searchResults if removing from playlistTracks.
     searchResults.unshift(track);
     setSearchResults([...searchResults]);
-    if (editMode) {
-      Spotify.deleteTrack(track.uri, playlistId).then(() => {
-        activateMsg('Track removed!', '#FF0000');
-      });
-    }
   }
 
   function savePlaylist() {
@@ -76,7 +66,11 @@ function App() {
       });
     }
     if (editMode) {
-      Spotify.renamePlaylist(playlistName, playlistId).then(() => {
+      // When saving an existing playlist, remove all previously saved tracks and then save all current playlist tracks to Spotify.
+      Spotify.renamePlaylist(playlistName, playlistId)
+      .then(Spotify.deleteTracks(oldTrackURIs, playlistId))
+      .then(Spotify.addTracks(trackURIs, playlistId))
+      .then(() => {
         activateMsg('Playlist updated!', '#228B22');
         setPlaylistName('New Playlist');
         setPlaylistTracks([]);

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -142,13 +142,17 @@ const Spotify = {
     })
   },
 
-  deleteTrack(trackURI, playlistId) {
+  deleteTracks(trackURIs, playlistId) {
     const accessToken = Spotify.getAccessToken();
     const headers = {Authorization: `Bearer ${accessToken}`};
+    const formattedTrackURIs = [];
+    for (let i=0; i<trackURIs.length; i++) {
+      formattedTrackURIs.push({uri: trackURIs[i]});
+    }
     return fetch(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`, {
       method: 'DELETE',
       headers: headers,
-      body: JSON.stringify({tracks: [{uri: trackURI}]})
+      body: JSON.stringify({tracks: formattedTrackURIs})
     })
   },
 

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -132,13 +132,13 @@ const Spotify = {
     })
   },
 
-  addTrack(trackURI, playlistId) {
+  addTracks(trackURIs, playlistId) {
     const accessToken = Spotify.getAccessToken();
     const headers = {Authorization: `Bearer ${accessToken}`};
     return fetch(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`, {
       method: 'POST',
       headers: headers,
-      body: JSON.stringify({uris: [trackURI]})
+      body: JSON.stringify({uris: trackURIs})
     })
   },
 


### PR DESCRIPTION
Removed previous functionality whereby Spotify API was queried every time a track was added or removed from an existing playlist. Instead, the API is called only when the user clicks on the 'SAVE TO SPOTIFY' button. At this point, the old track list is replaced with the new track list as displayed in the UI via DELETE and POST requests.

This both greatly reduces the number of API requests and makes the app operate more intuitively. If the user closed or refreshed the page midway through editing a playlist, it would not get saved. This is in contrast to before the change, where the button only saved the playlist name and reset the name and track list.